### PR TITLE
Tag entities that have been upgraded to transient modifiers

### DIFF
--- a/src/main/java/ar/emily/adorena/AdorenaPlugin.java
+++ b/src/main/java/ar/emily/adorena/AdorenaPlugin.java
@@ -97,19 +97,19 @@ public final class AdorenaPlugin extends JavaPlugin implements Listener {
     getServer().getWorlds().stream()
         .map(World::getLivingEntities)
         .flatMap(Collection::stream)
-        .forEach(this.effectProcessor::loadEffects);
+        .forEach(target -> this.effectProcessor.loadEffects(target, true));
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void on(final PlayerJoinEvent event) {
-    this.effectProcessor.loadEffects(event.getPlayer());
+    this.effectProcessor.loadEffects(event.getPlayer(), false);
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void on(final EntitiesLoadEvent event) {
     for (final Entity entity : event.getEntities()) {
       if (entity instanceof final LivingEntity target) {
-        this.effectProcessor.loadEffects(target);
+        this.effectProcessor.loadEffects(target, false);
       }
     }
   }

--- a/src/main/java/ar/emily/adorena/kitchen/EffectProcessor.java
+++ b/src/main/java/ar/emily/adorena/kitchen/EffectProcessor.java
@@ -27,6 +27,7 @@ public final class EffectProcessor {
 
   private static final NamespacedKey GROWTH_MODIFIER_KEY = new NamespacedKey("adorena", "growth");
   private static final NamespacedKey COUNTER_PDC_KEY = new NamespacedKey("adorena", "counter");
+  private static final NamespacedKey USES_TRANSIENT_KEY = new NamespacedKey("adorena", "uses_transient");
 
   private static AttributeModifier createModifier(final double amount) {
     return new AttributeModifier(
@@ -61,9 +62,13 @@ public final class EffectProcessor {
     this.config.attachReloadListener(this::rebuildCooldownSets);
   }
 
-  public void loadEffects(final LivingEntity target) {
+  public void loadEffects(final LivingEntity target, final boolean needsReload) {
     final int amplitude = getEffectsAmplitude(target);
-    resetEffects(target); // remove potentially old/persistent modifiers
+    final boolean usesTransient = target.getPersistentDataContainer().getOrDefault(USES_TRANSIENT_KEY, PersistentDataType.BOOLEAN, false);
+    if (!usesTransient || needsReload) {
+      resetEffects(target); // remove old persistent modifiers
+      target.getPersistentDataContainer().set(USES_TRANSIENT_KEY, PersistentDataType.BOOLEAN, true);
+    }
     if (amplitude != 0) {
       setEffectsAmplitude(target, amplitude);
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,3 +6,4 @@ authors:
   - emilyy-dev
   - rymiel
 prefix: "アドレナ"
+load: STARTUP


### PR DESCRIPTION
Latest version of adorena uses transient modifiers instead of persistent ones for scaling. For compatibility, old persistent modifiers were removed on entity load or player join. However, this incurs a cost of iterating over every attribute for each entity or player loaded to reset old persistent modifiers.

This PR adds a PDC tag to entities that have already performed this reset, and this reset is not run again for that entity or player. Note that the reset is still run for every entity on config reload, since the used attributes may have changed. It does not need to be run on join or load, since the transient nature of these attributes ensures that no stale ones are left behind.

Fixes #3

Also changes load setting to `STARTUP` to make sure entities in spawn chunks are properly scaled.